### PR TITLE
perf(retractor): eliminacja kopii obiektu query w goracej sciezce pro…

### DIFF
--- a/src/retractor/lib/dataModel.cpp
+++ b/src/retractor/lib/dataModel.cpp
@@ -134,7 +134,7 @@ void dataModel::processRows(const std::set<std::string> &inSet) {
   }
 
   // Then - process all declarations to unlock them for next step
-  for (auto q : coreInstance_) {
+  for (const auto &q : coreInstance_) {
     if (!inSet.contains(q.id)) continue;  // Drop off rows that not computed now
     if (!q.isDeclaration()) continue;     // first declarations need to be processed
 
@@ -149,7 +149,7 @@ void dataModel::processRows(const std::set<std::string> &inSet) {
 }
 
 void dataModel::constructInputPayload(const std::string &instance) {
-  auto qry = coreInstance_[instance];
+  const query &qry = coreInstance_[instance];
 
   if (qry.lProgram.size() >= 4) {
     FatalError("dataModel::constructInputPayload: program not optimized — {} tokens for query '{}', expected < 4",


### PR DESCRIPTION
…cessRows

qTree::operator[] zwraca query&, a constructInputPayload i petla deklaracji w processRows kopiowaly caly obiekt query (3 listy: lProgram/lSchema/lRules
+ stringi) na kazdy strumien/interwal (35 kopii/interwal na workloadzie rec205-detect). Zmiana kopii na referencje — ten sam odczyt, zero zmiany funkcjonalnosci.

Dowody (inwestygacja speed_improvement):
- licznik kopii query: 35/interwal -> 0/interwal (deterministyczny)
- ctest: 153/153 passed (w tym ut_dataModel-compile/-compare)
- E1 p50 (compute_ns processRows, sparowany, unpaced): 317.6 -> 281.7 us (-11.3%)
- E1 p99: 834.8 -> 762.1 us (-8.7%, brak regresji ogona)