### PR TITLE
eksperyment: nadzorca wczytuje konfiguracje badan przed checkoutem ga…

### DIFF
--- a/examples/experiment/JOURNAL.md
+++ b/examples/experiment/JOURNAL.md
@@ -2233,3 +2233,30 @@ albo fałszywy sukces**. Warto przejrzeć nadzorcę pod tym kątem systematyczni
    1960,8 µs, więc pojedynczy przebieg mógłby wypaść po drugiej stronie. Do rozstrzygnięcia
    powtórzeniem stopni 480/510 kilka razy, jeśli liczba ma trafić do artykułu jako ostra.
 3. Asercja pustej listy badań w nadzorcy (wyżej).
+
+## 2026-07-22 — nadzorca: konfiguracja badań wczytywana przed checkoutem gałęzi
+
+Zamknięcie punktu 3 z listy wyżej. Poprawka jest dwuczęściowa, bo sama asercja
+leczyłaby objaw, a nie przyczynę.
+
+Przyczyna: `mapfile` czytał plik konfiguracji tuż przed pętlą badań, czyli **po**
+przełączeniu drzewa roboczego na gałąź eksperymentu. Gdy gałąź stała na starszym
+masterze i nie zawierała jeszcze danego `campaign_*.csv`, plik znikał z drzewa
+i lista badań wychodziła pusta — kampania kończyła się kodem 0 z pustym katalogiem
+wyników.
+
+Poprawka: odczyt przeniesiony w górę, tuż za weryfikację `master == origin/master`,
+gdzie plik jest gwarantowany. Lista trafia do pamięci (`ROWS`, `TOTAL`) i nie jest
+już czytana ponownie, więc dalsze przełączenia drzewa nie mogą jej zmienić. Do tego
+asercja `TOTAL > 0` i log potwierdzający liczbę wczytanych badań — nadzorca ma teraz
+mówić, ile zamierza wykonać, zanim zacznie.
+
+Zweryfikowane: plik z samym nagłówkiem → `die`, `campaign_rate_fine.csv` → 5 badań.
+Kolejność w skrypcie: `git checkout master` (77), odczyt konfiguracji (89–93),
+`git checkout $BRANCH` (108).
+
+To domyka trzy usterki tej samej rodziny znalezione w tym harnessie — zawieszenie
+bez timeoutu, timeout nieosiągalny z konstrukcji pętli, pusta lista badań bez
+błędu. Wspólny wzorzec: **stan zewnętrzny zmienia się pod skryptem, a skrypt nie
+sprawdza, czy to, na czym pracuje, nadal istnieje**. Warto przy okazji kolejnej
+zmiany przejrzeć nadzorcę pod tym kątem, zamiast czekać na czwarty przypadek.

--- a/examples/experiment/start_supervisor.sh
+++ b/examples/experiment/start_supervisor.sh
@@ -67,7 +67,6 @@ done
   log "UWAGA: kampania 'clients' uzywa rate-hz=360 (domyslnie). Jesli kampania 'rate' wskazala inna stabilna czestosc, podaj ja przez --rate-hz."
 
 CONFIG_CSV="$SCRIPT_DIR/config/campaign_${CAMPAIGN}.csv"
-[ -f "$CONFIG_CSV" ] || die "Brak pliku konfiguracji: $CONFIG_CSV"
 
 log "=== Kampania '$CAMPAIGN' na branchu $BRANCH (worker=$WORKER_HOST, sink=$SINK) ==="
 
@@ -79,6 +78,19 @@ git checkout master
 [ -z "$(git status --short)" ] || die "Working tree na nadzorcy nie jest czysty -- zacommituj lub odloz zmiany"
 [ "$(git rev-parse master)" = "$(git rev-parse origin/master)" ] || \
   die "master na nadzorcy rozjechal sie z origin/master -- zrob 'git pull' (lub push) przed eksperymentem"
+
+# --- Konfiguracja badan: WCZYTAC TERAZ, na masterze --------------------------
+# Lista badan jest wczytywana do pamieci tutaj, a nie tuz przed petla, bo ponizej
+# przelaczamy drzewo robocze na branch eksperymentu. Gdy branch stoi na starszym
+# masterze i nie zawiera jeszcze tego pliku konfiguracji, plik znika z drzewa --
+# a odczyt tuz przed petla dawal wtedy PUSTA liste, czyli kampanie konczaca sie
+# kodem 0 z pustym katalogiem wynikow. Cicha porazka wygladajaca jak sukces
+# (zaobserwowane przy starcie rate_fine, JOURNAL.md 2026-07-22).
+[ -f "$CONFIG_CSV" ] || die "Brak pliku konfiguracji: $CONFIG_CSV"
+mapfile -t ROWS < <(tail -n +2 "$CONFIG_CSV")
+TOTAL=${#ROWS[@]}
+[ "$TOTAL" -gt 0 ] || die "Plik konfiguracji nie zawiera zadnego badania: $CONFIG_CSV"
+log "Wczytano $TOTAL badan z $(basename "$CONFIG_CSV")."
 
 log "Sprawdzam synchronizacje master <-> origin/master (worker)..."
 ssh_worker "$WORKER_HOST" "
@@ -181,9 +193,7 @@ EOF
 )"
 printf '%s\n' "$CAMPAIGN_README" | ssh_worker "$WORKER_HOST" "mkdir -p '$WORKER_REPO/$CAMPAIGN_RESULTS_DIR' && cat > '$WORKER_REPO/$CAMPAIGN_RESULTS_DIR/README.md'"
 
-# --- Petla badan ------------------------------------------------------------
-mapfile -t ROWS < <(tail -n +2 "$CONFIG_CSV")
-TOTAL=${#ROWS[@]}
+# --- Petla badan (ROWS/TOTAL wczytane na masterze, przed checkoutem brancha) --
 IDX=0
 for row in "${ROWS[@]}"; do
   IDX=$((IDX + 1))


### PR DESCRIPTION
…lezi

Trzecia usterka rodziny "cicha porazka" w tym harnessie. mapfile czytal plik konfiguracji tuz przed petla badan, czyli PO przelaczeniu drzewa roboczego na branch eksperymentu. Gdy branch stal na starszym masterze i nie zawieral jeszcze danego campaign_*.csv, plik znikal z drzewa, lista badan wychodzila pusta, a kampania konczyla sie kodem 0 z pustym katalogiem wynikow -- bez bledu i bez ostrzezenia. Zaobserwowane przy starcie rate_fine (JOURNAL.md 2026-07-22), obejsciem bylo przebazowanie galezi eksperymentu na aktualny master.

Poprawka dwuczesciowa, bo sama asercja leczylaby objaw:

- odczyt przeniesiony w gore, tuz za weryfikacje master == origin/master, gdzie plik jest gwarantowany; lista trafia do pamieci (ROWS, TOTAL) i nie jest juz czytana ponownie, wiec dalsze przelaczenia drzewa nie moga jej zmienic,
- asercja TOTAL > 0 plus log z liczba wczytanych badan -- nadzorca mowi, ile zamierza wykonac, zanim zacznie.

Zweryfikowane: plik z samym naglowkiem -> die, campaign_rate_fine.csv -> 5 badan. Kolejnosc: git checkout master (77), odczyt konfiguracji (89-93), git checkout $BRANCH (108).

Wspolny wzorzec trzech usterek: stan zewnetrzny zmienia sie pod skryptem, a skrypt nie sprawdza, czy to, na czym pracuje, nadal istnieje.