### PR TITLE
Klient xqry: diagnostyka na stderr i realny budzet czekania (issue_217)

### DIFF
--- a/src/common/uxSysTermTools.cpp
+++ b/src/common/uxSysTermTools.cpp
@@ -160,7 +160,13 @@ std::string setupLoggerMain(const std::string &loggerFile, bool dual, bool servi
   constexpr auto common_log_pattern = "%C%m%d %T.%e %^%s:%# [%L] %v%$";
 
   if (dual) {
-    auto console_sink = std::make_shared<spdlog::sinks::stdout_sink_mt>();
+    // Diagnostyka na STDERR, nie na STDOUT. Stdout jest u klienta strumieniem
+    // DANYCH (`std::print` w formatterach), więc mieszanie z nim komunikatów
+    // błędu psuło jedno i drugie: dane były zanieczyszczone, a błędy nie do
+    // znalezienia. Harness pomiarowy uruchamia klienta jako `>/dev/null 2>err`,
+    // przez co każda awaria wyglądała jak zniknięcie bez komunikatu i zatrzymała
+    // dwie kampanie na fałszywej hipotezie o crashu (issue_217).
+    auto console_sink = std::make_shared<spdlog::sinks::stderr_sink_mt>();
 
     console_sink->set_pattern("%v%$");
     console_sink->set_level(spdlog::level::trace);

--- a/src/qry/ipc_transport.cpp
+++ b/src/qry/ipc_transport.cpp
@@ -7,7 +7,6 @@
 #include <chrono>
 #include <cstring>
 #include <memory>
-#include <print>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -124,15 +123,18 @@ ptree IpcTransport::netClient(const std::string &netCommand, const std::string &
       it = mymap->find(processId);
     }
 
-    int cntr(clientResponseMaxFails_);
-    while (it == mymap->end() && cntr != 0) {
+    // Budżet liczony ZEGAREM, a nie liczbą obrotów pętli. Obrót to sen plus
+    // `lock` na muteksie współdzielonym z wątkiem emisji serwera, więc na
+    // obciążonej maszynie trwa dłużej niż sam interwał — a wtedy liczenie prób
+    // skracało faktyczne czekanie dokładnie w sytuacji, w której potrzebne było
+    // najdłuższe (issue_217).
+    const auto deadline = std::chrono::steady_clock::now() + clientResponseMaxFails_ * ipc::kClientResponsePollInterval;
+    while (it == mymap->end() && std::chrono::steady_clock::now() < deadline) {
       std::this_thread::sleep_for(ipc::kClientResponsePollInterval);
       IPC::scoped_lock<IPC::named_mutex> lock(mapMutex);
       it = mymap->find(processId);
-      --cntr;
     }
     if (it == mymap->end()) {
-      std::println("server not found");
       SPDLOG_ERROR("server not found");
       done = true;
       pt_response.put("error.response", "server not found");

--- a/src/qry/ipc_transport.hpp
+++ b/src/qry/ipc_transport.hpp
@@ -7,8 +7,19 @@
 
 // Pojemność wewnętrznej kolejki SPSC między wątkiem producenta (IPC) a wątkiem select().
 // Wartość musi być potęgą 2 i wystarczająco duża by zaabsorbować burstowe dane strumieniowe.
-constexpr int kSpscQueueCapacity                         = 1024;
-constexpr int kIpcTransportDefaultClientResponseMaxFails = 10;
+constexpr int kSpscQueueCapacity = 1024;
+
+// Budżet klienta na odpowiedź serwera; efektywny czas to ta liczba razy
+// ipc::kClientResponsePollInterval (300 × 10 ms = 3 s).
+//
+// Poprzednie 10 prób (100 ms) było za mało. Wątek komunikacyjny serwera powstaje
+// przed `rtActivate`, więc zostaje SCHED_OTHER, podczas gdy wątek przetwarzania
+// dostaje SCHED_FIFO; przy pracy pod `taskset` na jednym rdzeniu wątek
+// komunikacyjny dostaje CPU dopiero w oknie throttlingu RT, którego okres jest
+// rzędu sekundy. Klient poddawał się, zanim serwer w ogóle został zaszeregowany
+// — i kończył się kodem `timed_out`, co harness pomiarowy odczytywał jako
+// zniknięcie klienta (issue_217).
+constexpr int kIpcTransportDefaultClientResponseMaxFails = 300;
 
 // Ile razy producent ponawia otwarcie własnej kolejki odpowiedzi, zanim uzna, że
 // serwer jej nie utworzy. Kolejka powstaje po stronie serwera w reakcji na

--- a/src/qry/qry.hpp
+++ b/src/qry/qry.hpp
@@ -10,7 +10,7 @@
 #include "ipc_transport.hpp"
 
 inline constexpr int kDefaultServerNoDataTimeoutMs{10'000};
-inline constexpr int kDefaultClientResponseMaxFails{10};
+inline constexpr int kDefaultClientResponseMaxFails{kIpcTransportDefaultClientResponseMaxFails};
 
 /// Wynik `qry::select`. Rozróżnia tryby porażki, bo wszystkie trzy dawały
 /// wcześniej albo kod 0, albo mylący komunikat o innym błędzie (issue_215).

--- a/src/qry/qryLauncher.cpp
+++ b/src/qry/qryLauncher.cpp
@@ -178,16 +178,16 @@ int main(int argc, char *argv[]) {
         case selectResult::ok:
           break;
         case selectResult::streamNotFound:
-          std::println("xqry: {}: {}", sInputStream, toString(result));
+          std::println(std::cerr, "xqry: {}: {}", sInputStream, toString(result));
           return system::errc::no_such_file_or_directory;
         case selectResult::serverNoResponse:
-          std::println("xqry: {}: {}", sInputStream, toString(result));
+          std::println(std::cerr, "xqry: {}: {}", sInputStream, toString(result));
           return system::errc::timed_out;
         case selectResult::clientQueueMissing:
-          std::println("xqry: {}: {}", sInputStream, toString(result));
+          std::println(std::cerr, "xqry: {}: {}", sInputStream, toString(result));
           return system::errc::no_stream_resources;
         case selectResult::noData:
-          std::println("xqry: {}: {}", sInputStream, toString(result));
+          std::println(std::cerr, "xqry: {}: {}", sInputStream, toString(result));
           return system::errc::no_message_available;
       }
     } else {

--- a/src/retractor/README.md
+++ b/src/retractor/README.md
@@ -152,10 +152,14 @@ If any of those checks fail, xretractor reports a configuration error and stops.
 - `ipc.min_queue_elements` (int, default: `100`, must be `> 0`)
   - Minimum queue capacity regardless of stream interval.
 
-- `ipc.client_response_max_fails` (int, default: `10`, must be `> 0`)
-  - Number of xqry retries while waiting for response in shared memory.
-  - Effective wait time is roughly:
-    `client_response_max_fails * kClientResponsePollInterval`.
+- `ipc.client_response_max_fails` (int, default: `300`, must be `> 0`)
+  - Budget for xqry waiting for a response in shared memory.
+  - Effective wait time is a wall-clock deadline of
+    `client_response_max_fails * kClientResponsePollInterval` (300 × 10 ms = 3 s).
+  - The default is measured in seconds, not milliseconds, on purpose: the
+    server's command thread is SCHED_OTHER while its processing thread may run
+    SCHED_FIFO on the same pinned core, so it can wait a whole RT throttling
+    period before being scheduled (issue_217).
 
 #### [timing]
 
@@ -197,7 +201,7 @@ dir = "/var/lib/retractor/data"
 [ipc]
 queue_buffer_seconds = 10
 min_queue_elements = 100
-client_response_max_fails = 10
+client_response_max_fails = 300
 
 [timing]
 server_startup_wait_s = 30

--- a/src/retractor/lib/appConfig.hpp
+++ b/src/retractor/lib/appConfig.hpp
@@ -9,7 +9,9 @@
 namespace appcfg {
 inline constexpr int kDefaultIpcQueueBufferSeconds{10};
 inline constexpr int kDefaultIpcMinQueueElements{100};
-inline constexpr int kDefaultIpcClientResponseMaxFails{10};
+// 300 × ipc::kClientResponsePollInterval = 3 s. Powód wartości: patrz
+// kIpcTransportDefaultClientResponseMaxFails w src/qry/ipc_transport.hpp.
+inline constexpr int kDefaultIpcClientResponseMaxFails{300};
 inline constexpr int kDefaultTimingServerStartupWaitSeconds{30};
 inline constexpr int kDefaultTimingServerStartupPollIntervalMs{100};
 inline constexpr int kDefaultTimingQueryNoDataTimeoutMs{10'000};

--- a/test/IntegrationTest_serial/issue217_client_diag_stderr/CMakeLists.txt
+++ b/test/IntegrationTest_serial/issue217_client_diag_stderr/CMakeLists.txt
@@ -1,0 +1,18 @@
+# make install && ctest -R issue217_client_diag_stderr -V
+
+# Weryfikuje że xqry zgłasza awarię na STDERR, a nie wyłącznie na STDOUT.
+#
+# Scenariusz: - xqry wołany bez działającego serwera - asercja: kod wyjścia
+# różny od zera ORAZ niepusty stderr
+
+get_filename_component(TestID ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+set(TestID "it_${TestID}")
+
+add_test(
+  NAME ${TestID}-run
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND bash run.sh)
+
+# Dotyka obiektów IPC serwera -> nie może biec równolegle z testami startującymi
+# xretractor (flagi -k/-m są w run.sh, więc makro add_test ich nie widzi).
+set_tests_properties(${TestID}-run PROPERTIES RUN_SERIAL TRUE TIMEOUT 60)

--- a/test/IntegrationTest_serial/issue217_client_diag_stderr/run.sh
+++ b/test/IntegrationTest_serial/issue217_client_diag_stderr/run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Diagnostyka xqry musi trafiać na STDERR (issue_217).
+#
+# Klient logował przez `setupLoggerMain(argv[0], dual=true)`, którego console
+# sink to STDOUT, a ścieżki błędu w qryLauncher.cpp używały `std::println` —
+# również stdout. Na stderr nie szło nic. Harness pomiarowy uruchamia klienta
+# jako `xqry ... >/dev/null 2>xqry.err`, więc KAŻDA awaria klienta wyglądała
+# jak zniknięcie bez komunikatu: `xqry.err` miał 0 bajtów także w przebiegach
+# zakończonych sukcesem. Ta pozorna cichość zatrzymała dwie kampanie (K6b, K6c)
+# i utrzymywała fałszywą hipotezę o crashu klienta pod obciążeniem.
+set -e
+rm -f out.txt err.txt
+
+status=0
+xqry -s nosuchstream_issue217 >out.txt 2>err.txt || status=$?
+
+# Brak serwera (albo nieznany strumień) to awaria — klient nie może wyjść zerem.
+[ "$status" -ne 0 ] || {
+  echo "FAIL: xqry zakonczyl sie kodem 0 mimo braku serwera"
+  exit 1
+}
+
+# Sedno regresji: komunikat musi być tam, gdzie szuka go operator i harness.
+[ -s err.txt ] || {
+  echo "FAIL: xqry nie napisal nic na stderr (kod $status); komunikat poszedl na stdout:"
+  cat out.txt
+  exit 1
+}

--- a/test/UnitTest/test_ipc_transport.cpp
+++ b/test/UnitTest/test_ipc_transport.cpp
@@ -3,10 +3,17 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <functional>
 #include <string>
 #include <thread>
+#include <utility>
 
+#include <boost/container/map.hpp>
+#include <boost/container/string.hpp>
+#include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/ipc/message_queue.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include "constants.hpp"
@@ -114,4 +121,83 @@ TEST(IpcTransport, producer_reports_missing_queue_distinctly_from_normal_end) {
 
   boost::property_tree::ptree pt;
   EXPECT_FALSE(transport.popQueue(pt)) << "nie moze byc danych, skoro kolejki nie bylo";
+}
+
+// === Regresja defektu klienta wykrytego w kampanii K6c (issue_217) ===
+//
+// Klient „znikał" przy dołączaniu do obciążonego serwera. Nie był to crash:
+// kończył się czysto kodem `timed_out`, bo budżet oczekiwania na odpowiedź
+// serwera na `get` wynosił 10 prób × 10 ms = 100 ms. Wątek komunikacyjny
+// silnika (`commandProcessorLoop`) powstaje PRZED `rtActivate`, więc zostaje
+// SCHED_OTHER, podczas gdy wątek przetwarzania dostaje SCHED_FIFO 50; `taskset`
+// przypina oba do jednego rdzenia. Przy wysyceniu rdzenia wątek komunikacyjny
+// dostaje CPU dopiero w oknie throttlingu RT, a to trwa dłużej niż 100 ms.
+//
+// Zmierzone w kampanii: `W8_Q32` pracuje z duty ~200 % slotu, więc wysycenie
+// jest trwałe, a nie chwilowe.
+
+namespace {
+
+// Atrapa serwera: tworzy dokładnie te obiekty IPC, których szuka `netClient`,
+// ale NIGDY nie wstawia odpowiedzi do mapy. Odwzorowuje serwer, którego wątek
+// komunikacyjny jest zagłodzony przez wątek czasu rzeczywistego.
+class SilentServer {
+  using segment_manager_t = boost::interprocess::managed_shared_memory::segment_manager;
+  using CharAllocator     = boost::interprocess::allocator<char, segment_manager_t>;
+  using IPCString         = boost::container::basic_string<char, std::char_traits<char>, CharAllocator>;
+  using ValueType         = std::pair<const int, IPCString>;
+  using ShmemAllocator    = boost::interprocess::allocator<ValueType, segment_manager_t>;
+  using IPCMap            = boost::container::map<int, IPCString, std::less<>, ShmemAllocator>;
+
+  boost::interprocess::managed_shared_memory segment_;
+  boost::interprocess::named_mutex mutex_;
+  boost::interprocess::message_queue queue_;
+
+ public:
+  SilentServer()
+      : segment_(boost::interprocess::open_or_create, std::string(ipc::kShmemSegment).c_str(), ipc::kShmemSegmentSize),
+        mutex_(boost::interprocess::open_or_create, std::string(ipc::kMapMutex).c_str()),
+        queue_(boost::interprocess::open_or_create, std::string(ipc::kQueryQueue).c_str(), ipc::kQueryQueueMaxMessages,
+               ipc::kQueryQueueMaxMessageSize) {
+    segment_.construct<IPCMap>(std::string(ipc::kMapObject).c_str())(std::less<>(),
+                                                                     ShmemAllocator(segment_.get_segment_manager()));
+  }
+
+  ~SilentServer() {
+    boost::interprocess::shared_memory_object::remove(std::string(ipc::kShmemSegment).c_str());
+    boost::interprocess::named_mutex::remove(std::string(ipc::kMapMutex).c_str());
+    boost::interprocess::message_queue::remove(std::string(ipc::kQueryQueue).c_str());
+  }
+};
+
+}  // namespace
+
+// Domyślny budżet klienta musi przetrwać serwer, który przez chwilę nie dostaje
+// CPU. 100 ms nie wystarczało: okno throttlingu RT ma okres rzędu sekundy, więc
+// klient poddawał się, zanim wątek komunikacyjny w ogóle został zaszeregowany.
+TEST(IpcTransport, netClient_default_budget_survives_briefly_starved_server) {
+  const SilentServer server;
+
+  IpcTransport transport;  // domyślny budżet — to on był defektem
+  const auto start = std::chrono::steady_clock::now();
+  const auto pt    = transport.netClient("get", "");
+  const auto spent = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+
+  EXPECT_EQ(pt.get<std::string>("error.response", ""), "server not found") << "milczacy serwer musi dac rozpoznawalny blad";
+  EXPECT_GE(spent.count(), 2000) << "domyslny budzet " << spent.count() << " ms nie przetrwa zaglodzonego watku komunikacyjnego";
+}
+
+// Budżet ma być liczony ZEGAREM, a nie liczbą obrotów pętli. Przy liczeniu
+// obrotów przeciążony klient (albo dłuższy `lock`) skracał faktyczne czekanie
+// poniżej zadeklarowanego, czyli dokładnie wtedy, gdy potrzebne było najdłuższe.
+TEST(IpcTransport, netClient_honours_configured_budget_by_wall_clock) {
+  const SilentServer server;
+
+  IpcTransport transport(120, kIpcTransportDefaultResponseQueueOpenMaxFails);  // 120 × 10 ms = 1200 ms
+  const auto start = std::chrono::steady_clock::now();
+  transport.netClient("get", "");
+  const auto spent = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+
+  EXPECT_GE(spent.count(), 1000) << "czekano " << spent.count() << " ms zamiast zadeklarowanych 1200 ms";
+  EXPECT_LE(spent.count(), 4000) << "czekano " << spent.count() << " ms, budzet ma byc ograniczony z gory";
 }


### PR DESCRIPTION
Kampania pomiarowa dwukrotnie zatrzymywala sie na "kliencie, ktory znika bez komunikatu". Klient nie ulegal awarii: konczyl sie czysto kodem timed_out po ~100 ms, a komunikat byl wyrzucany do /dev/null. Dwie przyczyny, obie naprawione.

1. Diagnostyka szla na STDOUT, nigdy na STDERR.

setupLoggerMain(dual=true) uzywal stdout_sink_mt, a sciezki bledu w qryLauncher.cpp uzywaly std::println bez strumienia. Stdout jest u klienta strumieniem DANYCH, wiec komunikaty bledu jednoczesnie zanieczyszczaly dane i byly nie do znalezienia. Harness uruchamia klienta jako `>/dev/null 2>err`, wiec xqry.err mial 0 bajtow w KAZDYM przebiegu -- takze zakonczonym sukcesem. Puste stderr nie bylo objawem, tylko artefaktem konstrukcji.

2. Budzet 100 ms na pierwsza odpowiedz serwera byl nie do utrzymania.

Watek komunikacyjny serwera (commandProcessorLoop) powstaje przed rtActivate, wiec zostaje SCHED_OTHER, podczas gdy watek przetwarzania dostaje SCHED_FIFO 50; taskset przypina oba do jednego rdzenia. Przy wysyceniu rdzenia watek komunikacyjny dostaje CPU dopiero w oknie throttlingu RT, ktorego okres jest rzedu sekundy -- a klient poddawal sie po 10 probach x 10 ms.

Budzet jest teraz liczony zegarem (obrot petli to sen plus lock na muteksie dzielonym z watkiem emisji, wiec liczenie prob skracalo faktyczne czekanie dokladnie wtedy, gdy potrzebne bylo najdluzsze) i domyslnie wynosi 3 s.

Regresje, obie wykazane jako czerwone przed naprawa:
- ut_ipc_transport netClient_default_budget_survives_briefly_starved_server (atrapa serwera, ktora nigdy nie odpowiada; przed naprawa 101 ms zamiast 3 s)
- it_issue217_client_diag_stderr (xqry bez serwera musi pisac na stderr; przed naprawa stderr pusty, komunikat na stdout)

Zweryfikowane: ctest 172/172 w Debug i w Release.